### PR TITLE
feat: Introduce the default value option to the @Value decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,12 @@ export class DatabaseConfiguration {
   host: string;
 
   @Value('database.port', {
-    parse: (value: any) => parseInt(value)
+    parse: parseInt
   })
   port: number;
 
   @Value('database.metadata', {
-    parse: (value: any) => JSON.parse(value)
+    parse: JSON.parse
   })
   metadata: MetadataType;
 }
@@ -138,13 +138,31 @@ export class AppService {
 
 ### Variables Expansion
 
-You can make use of variable expasion in your configuration files:
+You can make use of variable expansion in your configuration files:
 
 ```
 MY_API_KEY=${MY_SECRET} // --> MY_API_KEY=TEST
 ANY_OTHER_CONFIG=TEST
 MY_SECRET=TEST
 APP_CLIENT_ID=${NON_EXISTING_ENV:-DEFAULT_ID} // --> APP_CLIENT_ID=DEFAULT_ID
+```
+
+### Defining Default Configuration Values
+
+Other than defining default values with variables expansion, you can also define a default value to an attribute using the `default` option provided by the `@Value()` decorator:
+
+```js
+@Configuration()
+export class DatabaseConfiguration {
+  @Value('DB_HOST', { default: 'localhost' })
+  host: string;
+
+  @Value('DB_PORT', {
+    parse: parseInt,
+    default: 3306
+  })
+  port: number;
+}
 ```
 
 ### Dealing with Secrets
@@ -212,7 +230,7 @@ export interface MyDBConfig {
 @Configuration()
 export class SuperSecretConfiguration {
   @Value('db-json-config', {
-    parse: (value: any) => JSON.parse(value)
+    parse: JSON.parse
   })
   myDbConfig: MyDBConfig;
 }
@@ -237,7 +255,7 @@ export class MyConfiguration {
 
 ### Overwrite Default Options
 
-You can overwrite default module otions by providing an object as argumento to the `forRootAsync()` method:
+You can overwrite default module options by providing an object as argument to the `forRootAsync()` method:
 
 ```js
 /**

--- a/src/configify.module.ts
+++ b/src/configify.module.ts
@@ -6,7 +6,7 @@ import * as fs from 'fs';
 import { resolve } from 'path';
 import {
   AwsSecretsManagerConfigurationResolver,
-  ConfigfyModuleOptions,
+  ConfigifyModuleOptions,
   ConfigurationParserFactory,
   ConfigurationProviders,
   ConfigurationRegistry,
@@ -51,12 +51,12 @@ export class ConfigifyModule {
    * AWS Secrets Manager and AWS Parameters Store.
    */
   private static readonly SECRETS_RESOLVER_PIPELINE = [
-    (options: ConfigfyModuleOptions) =>
+    (options: ConfigifyModuleOptions) =>
       new AwsSecretsManagerConfigurationResolver(
         options.secretsManagerClient || new SecretsManagerClient(),
       ),
 
-    (options: ConfigfyModuleOptions) =>
+    (options: ConfigifyModuleOptions) =>
       new AwsParameterStoreConfigurationResolver(
         options.ssmClient || new SSMClient(),
       ),
@@ -71,11 +71,11 @@ export class ConfigifyModule {
    *
    * The configuration key pair values will also be available on process.env object.
    *
-   * @param   { ConfigfyModuleOptions } options The module config options
+   * @param   { ConfigifyModuleOptions } options The module config options
    * @returns { DynamicModule }         module  The configy module
    */
   static async forRootAsync(
-    options: ConfigfyModuleOptions = {},
+    options: ConfigifyModuleOptions = {},
   ): Promise<DynamicModule> {
     const settings = { ...options, ...DefaultConfigfyModuleOptions };
     const files = this.resolveConfigurationFiles(settings.configFilePath);
@@ -110,12 +110,12 @@ export class ConfigifyModule {
    * Runs the secrets resolver pipeline.
    *
    * @param   {Record<string, any>}            config the configuration object
-   * @param   {ConfigfyModuleOptions}          options the module options
+   * @param   {ConfigifyModuleOptions}          options the module options
    * @returns {Promise<Record<string, any>>}   the resolved secrets
    */
   private static async runSecretsResolverPipeline(
     config: Record<string, any>,
-    options: ConfigfyModuleOptions,
+    options: ConfigifyModuleOptions,
   ): Promise<Record<string, any>> {
     const secrets = {};
     for (const buildResolver of this.SECRETS_RESOLVER_PIPELINE) {

--- a/src/configify.module.ts
+++ b/src/configify.module.ts
@@ -151,9 +151,11 @@ export class ConfigifyModule {
         );
 
         const parse = metadata.options?.parse;
-        const value = parse
-          ? parse(process.env[metadata.key])
-          : process.env[metadata.key];
+
+        const defaultValue =
+          process.env[metadata.key] || metadata.options?.default;
+
+        const value = parse ? parse(defaultValue) : defaultValue;
 
         instance[attribute] = value;
       }

--- a/src/configify.module.ts
+++ b/src/configify.module.ts
@@ -10,7 +10,7 @@ import {
   ConfigurationParserFactory,
   ConfigurationProviders,
   ConfigurationRegistry,
-  DefaultConfigfyModuleOptions,
+  DefaultConfigifyModuleOptions,
 } from './configuration';
 import { AwsParameterStoreConfigurationResolver } from './configuration/resolvers/aws/parameter-store-configuration.resolver';
 import { Variables } from './interpolation/variables';
@@ -77,7 +77,7 @@ export class ConfigifyModule {
   static async forRootAsync(
     options: ConfigifyModuleOptions = {},
   ): Promise<DynamicModule> {
-    const settings = { ...options, ...DefaultConfigfyModuleOptions };
+    const settings = { ...options, ...DefaultConfigifyModuleOptions };
     const files = this.resolveConfigurationFiles(settings.configFilePath);
 
     const envVars = settings.ignoreEnvVars ? {} : process.env;

--- a/src/configuration/configuration-options.interface.ts
+++ b/src/configuration/configuration-options.interface.ts
@@ -44,7 +44,7 @@ export interface ConfigifyModuleOptions {
 /**
  * The default module options
  */
-export const DefaultConfigfyModuleOptions: ConfigifyModuleOptions = {
+export const DefaultConfigifyModuleOptions: ConfigifyModuleOptions = {
   ignoreConfigFile: false,
   ignoreEnvVars: false,
   expandConfig: true,

--- a/src/configuration/configuration-options.interface.ts
+++ b/src/configuration/configuration-options.interface.ts
@@ -4,7 +4,7 @@ import { SSMClient } from '@aws-sdk/client-ssm';
 /**
  * The configuration options interface
  */
-export interface ConfigfyModuleOptions {
+export interface ConfigifyModuleOptions {
   /**
    * Ignores any config file.
    * The default value is false;
@@ -44,7 +44,7 @@ export interface ConfigfyModuleOptions {
 /**
  * The default module options
  */
-export const DefaultConfigfyModuleOptions: ConfigfyModuleOptions = {
+export const DefaultConfigfyModuleOptions: ConfigifyModuleOptions = {
   ignoreConfigFile: false,
   ignoreEnvVars: false,
   expandConfig: true,

--- a/src/decorators/value.decorator.ts
+++ b/src/decorators/value.decorator.ts
@@ -15,7 +15,17 @@ export const VALUE_PROPERTIES_METADATA = Symbol.for('__properties__');
  * Allows custom parsing to configuration values
  */
 export interface ValueOptions {
-  parse: (value: any) => any;
+  /**
+   * Parses the configuration value.
+   * @param value
+   * @returns parsed value
+   */
+  parse?: (value: any) => unknown;
+
+  /**
+   * Sets a default value if the configuration key is not found.
+   */
+  default?: any;
 }
 
 /**

--- a/test/config/complex-dot-env.configuration.ts
+++ b/test/config/complex-dot-env.configuration.ts
@@ -26,4 +26,10 @@ export class ComplexDotEnvConfiguration {
 
   @Value('JSON_CONTENT', { parse: (value: any) => JSON.parse(value) })
   jsonContent: DotEnvJsonContent;
+
+  @Value('NON_EXISTING_ENV', { default: 'test_default_value' })
+  defaultValue: string;
+
+  @Value('NON_EXISTING_ENV', { parse: parseInt, default: '1' })
+  parsedDefaultValue: number;
 }

--- a/test/config/complex-json.configuration.ts
+++ b/test/config/complex-json.configuration.ts
@@ -19,4 +19,10 @@ export class ComplexJsonConfiguration {
 
   @Value('aws-parameter-store.secret')
   awsParameterStoreSecret: string;
+
+  @Value('non-existing-key', { default: true })
+  defaultBoolean: boolean;
+
+  @Value('non-existing-key', { parse: parseInt, default: '1' })
+  parsedDefaultValue: number;
 }

--- a/test/config/complex-yml.configuration.ts
+++ b/test/config/complex-yml.configuration.ts
@@ -28,4 +28,10 @@ export class ComplexYmlConfiguration {
     parse: (value: any) => JSON.parse(value),
   })
   jsonContent: YmlJsonContent;
+
+  @Value('non-existing-key', { default: 'test_default_value' })
+  defaultValue: string;
+
+  @Value('non-existing-key', { parse: parseInt, default: '1' })
+  parsedDefaultValue: number;
 }

--- a/test/configfy.module.spec.ts
+++ b/test/configfy.module.spec.ts
@@ -3,6 +3,7 @@ import {
   secretsManagerSendMock,
   systemsManagerSendMock,
 } from './mock/aws.mock';
+
 import { ValueProvider } from '@nestjs/common';
 import { resolve } from 'path';
 import { ConfigifyModule } from '../src';
@@ -50,6 +51,8 @@ describe('ConfigifyModule', () => {
         jsonContent: {
           host: 'localhost',
         },
+        defaultValue: 'test_default_value',
+        parsedDefaultValue: 1,
       });
     });
 
@@ -82,6 +85,8 @@ describe('ConfigifyModule', () => {
         jsonContent: {
           host: 'localhost',
         },
+        defaultValue: 'test_default_value',
+        parsedDefaultValue: 1,
       });
     });
 
@@ -111,6 +116,8 @@ describe('ConfigifyModule', () => {
         booleanContent: true,
         awsSecretsManagerSecret: secret,
         awsParameterStoreSecret: secret,
+        defaultBoolean: true,
+        parsedDefaultValue: 1,
       });
     });
   });


### PR DESCRIPTION
This PR introduces a `default` option to the `@Value()` decorator options, allowing setting default values when an environment variable is not found or it has no value set to it.

```js
@Configuration()
export class DatabaseConfiguration {
  @Value('DB_HOST', { default: 'localhost' })
  host: string;

  @Value('DB_PORT', {
    parse: parseInt,
    default: 3306
  })
  port: number;
}
```

Fixes #58 