### PR TITLE
fix: Error types when noImplicitAny is set to false

### DIFF
--- a/src/configify.module.ts
+++ b/src/configify.module.ts
@@ -134,7 +134,7 @@ export class ConfigifyModule {
    * @returns {ConfigurationProviders} the module configuration providers
    */
   private static buildConfigurationProviders(): ConfigurationProviders {
-    const exports = [];
+    const exports: unknown[] = [];
     const providers: Provider[] = [];
 
     const registry = ConfigurationRegistry.getRegistry();

--- a/src/configuration/resolvers/aws/parameter-store-configuration.resolver.ts
+++ b/src/configuration/resolvers/aws/parameter-store-configuration.resolver.ts
@@ -106,7 +106,7 @@ export class AwsParameterStoreConfigurationResolver
   private buildBulkRequest(
     config: Record<string, any>,
   ): Promise<ResolvedValue>[] {
-    const promises = [];
+    const promises: Promise<ResolvedValue>[] = [];
     for (const [key, value] of Object.entries(config)) {
       promises.push(this.resolveSecretValue(key, value));
     }

--- a/src/configuration/resolvers/aws/secrets-manager-configuration.resolver.ts
+++ b/src/configuration/resolvers/aws/secrets-manager-configuration.resolver.ts
@@ -108,7 +108,7 @@ export class AwsSecretsManagerConfigurationResolver
   private buildBulkRequest(
     config: Record<string, any>,
   ): Promise<ResolvedValue>[] {
-    const promises = [];
+    const promises: Promise<ResolvedValue>[] = [];
     for (const [key, value] of Object.entries(config)) {
       promises.push(this.resolveSecretValue(key, value));
     }


### PR DESCRIPTION
Setting `noImplicitAny` to `false` causes type errors due to the lack of type definitions when initializing arrays.

Fixes: #66 