### PR TITLE
maint: decouple aws secrets resolver pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ By default, when bootstraping, the module will lookup for a `.env`, an `applicat
 my-web-app
 | .env
 | application.yml
+| application.json
 ```
 
-You can also provide the location of the configuration files by overring the configuration options.
+You can also provide the location of the configuration files by overriding the configuration options.
 
 ### Mapping Configuration Classes
 
@@ -171,7 +172,27 @@ export class DatabaseConfiguration {
 
 ### Dealing with Secrets
 
-Out of the box, this module can resolve AWS Secrets Manager and Parameter Store secrets.
+Out of the box, this module can resolve AWS Secrets Manager and Parameter Store secrets. For that, just need to choose which strategies you would like to use to resolve AWS secrets:
+
+```js
+// use default aws client instances
+ConfigifyModule.forRootAsync({
+  secretsResolverStrategies: [
+    AwsSecretsResolverFactory.defaultParameterStoreResolver(),
+    AwsSecretsResolverFactory.defaultSecretsManagerResolver(),
+   ],
+});
+
+// or provide your own aws client instances
+ConfigifyModule.forRootAsync({
+  secretsResolverStrategies: [
+    new AwsParameterStoreConfigurationResolver(new SSMClient())
+    new AwsSecretsManagerConfigurationResolver(
+      new SecretsManagerClient(),
+    ),
+   ],
+});
+```
 
 Every configuration attribute stating with `AWS_SECRETS_MANAGER`, `AWS_PARAMETER_STORE`, `aws-secrets-manager` and `aws-parameter-store` will be considered a special configuration attribute and the module will try to resolve it's remote value.
 
@@ -242,7 +263,7 @@ export class SuperSecretConfiguration {
 
 ### Validating Configuration Classes
 
-Depending on how critical a configuration is, you may want to validate it before bootstraping the application, for that you can use [class-validator](https://github.com/typestack/class-validator) to make sure your configuration is loaded correctly:
+Depending on how critical a configuration is, you may want to validate it before starting the application, for that you can use [class-validator](https://github.com/typestack/class-validator) to make sure your configuration is loaded correctly:
 
 ```js
 @Configuration()
@@ -286,16 +307,9 @@ configFilePath?: string | string[];
 expandConfig?: boolean;
 
 /**
-* The AWS Secrets Manager Client
-* If no client is provided, the module will create one.
-*/
-secretsManagerClient?: SecretsManagerClient;
-
-/**
-* The AWS Systems Manager Client
-* If no client is provided, the module will create one.
-*/
-ssmClient?: SSMClient;
+ * The secrets resolvers strategies
+ */
+secretsResolverStrategies?: ConfigurationResolver[];
 ```
 
 ## License

--- a/src/configuration/configuration-options.interface.ts
+++ b/src/configuration/configuration-options.interface.ts
@@ -1,5 +1,4 @@
-import { SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
-import { SSMClient } from '@aws-sdk/client-ssm';
+import { ConfigurationResolver } from './resolvers';
 
 /**
  * The configuration options interface
@@ -29,16 +28,9 @@ export interface ConfigifyModuleOptions {
   expandConfig?: boolean;
 
   /**
-   * The AWS Secrets Manager Client
-   * If no client is provided, the module will create one.
+   * The secrets resolvers strategies
    */
-  secretsManagerClient?: SecretsManagerClient;
-
-  /**
-   * The AWS Systems Manager Client
-   * If no client is provided, the module will create one.
-   */
-  ssmClient?: SSMClient;
+  secretsResolverStrategies?: ConfigurationResolver[];
 }
 
 /**

--- a/src/configuration/configuration-parser.interface.ts
+++ b/src/configuration/configuration-parser.interface.ts
@@ -1,5 +1,5 @@
 /**
- * The configuraion parser interface.
+ * The configuration parser interface.
  * This interface is implemented by all
  * the supported configuration parsers.
  */

--- a/src/configuration/resolvers/aws/aws-secrets-resolver.factory.ts
+++ b/src/configuration/resolvers/aws/aws-secrets-resolver.factory.ts
@@ -1,0 +1,32 @@
+import { SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
+import { SSMClient } from '@aws-sdk/client-ssm';
+import { ConfigurationResolver } from '../configuration-resolver.interface';
+import { AwsParameterStoreConfigurationResolver } from './parameter-store-configuration.resolver';
+import { AwsSecretsManagerConfigurationResolver } from './secrets-manager-configuration.resolver';
+
+/**
+ * The AWS secrets resolver factory.
+ * This class provides the default secrets resolvers for the module.
+ * The default secrets resolvers are:
+ * - Parameter Store
+ * - Secrets Manager
+ */
+export class AwsSecretsResolverFactory {
+  /**
+   * The default parameter store secrets resolver
+   * @returns {ConfigurationResolver} the default parameter store secrets resolver
+   */
+  static defaultParameterStoreResolver(): ConfigurationResolver {
+    return new AwsParameterStoreConfigurationResolver(new SSMClient());
+  }
+
+  /**
+   * The default secrets manager secrets resolver
+   * @returns {ConfigurationResolver} the default secrets manager secrets resolver
+   */
+  static defaultSecretsManagerResolver(): ConfigurationResolver {
+    return new AwsSecretsManagerConfigurationResolver(
+      new SecretsManagerClient(),
+    );
+  }
+}

--- a/src/configuration/resolvers/aws/index.ts
+++ b/src/configuration/resolvers/aws/index.ts
@@ -1,2 +1,3 @@
+export * from './aws-secrets-resolver.factory';
 export * from './parameter-store-configuration.resolver';
 export * from './secrets-manager-configuration.resolver';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './configify.module';
+export * from './configuration';
 export * from './decorators';

--- a/test/configfy.module.spec.ts
+++ b/test/configfy.module.spec.ts
@@ -7,6 +7,7 @@ import {
 import { ValueProvider } from '@nestjs/common';
 import { resolve } from 'path';
 import { ConfigifyModule } from '../src';
+import { AwsSecretsResolverFactory } from '../src/configuration';
 import { ComplexDotEnvConfiguration } from './config/complex-dot-env.configuration';
 import { ComplexJsonConfiguration } from './config/complex-json.configuration';
 import { ComplexYmlConfiguration } from './config/complex-yml.configuration';
@@ -33,6 +34,10 @@ describe('ConfigifyModule', () => {
       const file = resolve(process.cwd(), 'test/config/.complex.env');
       const module = await ConfigifyModule.forRootAsync({
         configFilePath: file,
+        secretsResolverStrategies: [
+          AwsSecretsResolverFactory.defaultParameterStoreResolver(),
+          AwsSecretsResolverFactory.defaultSecretsManagerResolver(),
+        ],
       });
 
       const provider = module.providers?.filter(
@@ -67,6 +72,10 @@ describe('ConfigifyModule', () => {
       const file = resolve(process.cwd(), 'test/config/.complex.yml');
       const module = await ConfigifyModule.forRootAsync({
         configFilePath: file,
+        secretsResolverStrategies: [
+          AwsSecretsResolverFactory.defaultParameterStoreResolver(),
+          AwsSecretsResolverFactory.defaultSecretsManagerResolver(),
+        ],
       });
 
       const provider = module.providers?.filter(
@@ -101,6 +110,10 @@ describe('ConfigifyModule', () => {
       const file = resolve(process.cwd(), 'test/config/.complex.json');
       const module = await ConfigifyModule.forRootAsync({
         configFilePath: file,
+        secretsResolverStrategies: [
+          AwsSecretsResolverFactory.defaultParameterStoreResolver(),
+          AwsSecretsResolverFactory.defaultSecretsManagerResolver(),
+        ],
       });
 
       const provider = module.providers?.filter(

--- a/test/jest.config.json
+++ b/test/jest.config.json
@@ -1,9 +1,11 @@
 {
   "moduleFileExtensions": ["js", "json", "ts"],
-  "rootDir": ".",
+  "rootDir": "../",
   "testEnvironment": "node",
   "testRegex": ".spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
-  }
+  },
+  "collectCoverage": true,
+  "collectCoverageFrom": ["src/**/*.(t|j)s"]
 }


### PR DESCRIPTION
This PR removes the direct dependency on AWS parameter store and secrets manager clients when running the secrets resolver pipeline.

This change allows users to choose if a secret needs to be resolved, which specific secrets resolver will be used, or even provide a custom secrets resolver by implementing the interface `ConfigurationResolver`:

```js
ConfigifyModule.forRootAsync(); // no secrets to be resolved
```

```js
// use default aws client instances
ConfigifyModule.forRootAsync({
  secretsResolverStrategies: [
    AwsSecretsResolverFactory.defaultParameterStoreResolver(), 
    AwsSecretsResolverFactory.defaultSecretsManagerResolver(),
   ],
});
```

```js
// provide your own aws client instances
ConfigifyModule.forRootAsync({
  secretsResolverStrategies: [
    new AwsParameterStoreConfigurationResolver(new SSMClient())
    new AwsSecretsManagerConfigurationResolver(
      new SecretsManagerClient(),
    ),
   ],
});
```
Fixes #72 