### PR TITLE
maint: config resolvers refactoring

### DIFF
--- a/src/configuration/resolvers/aws/aws-secrets-resolver.factory.ts
+++ b/src/configuration/resolvers/aws/aws-secrets-resolver.factory.ts
@@ -1,6 +1,7 @@
 import { SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
 import { SSMClient } from '@aws-sdk/client-ssm';
 import { ConfigurationResolver } from '../configuration-resolver.interface';
+import { RemoteConfigurationResolver } from '../remote-configuration.resolver';
 import { AwsParameterStoreConfigurationResolver } from './parameter-store-configuration.resolver';
 import { AwsSecretsManagerConfigurationResolver } from './secrets-manager-configuration.resolver';
 
@@ -17,7 +18,10 @@ export class AwsSecretsResolverFactory {
    * @returns {ConfigurationResolver} the default parameter store secrets resolver
    */
   static defaultParameterStoreResolver(): ConfigurationResolver {
-    return new AwsParameterStoreConfigurationResolver(new SSMClient());
+    const strategy = new AwsParameterStoreConfigurationResolver(
+      new SSMClient(),
+    );
+    return new RemoteConfigurationResolver(strategy);
   }
 
   /**
@@ -25,8 +29,9 @@ export class AwsSecretsResolverFactory {
    * @returns {ConfigurationResolver} the default secrets manager secrets resolver
    */
   static defaultSecretsManagerResolver(): ConfigurationResolver {
-    return new AwsSecretsManagerConfigurationResolver(
+    const strategy = new AwsSecretsManagerConfigurationResolver(
       new SecretsManagerClient(),
     );
+    return new RemoteConfigurationResolver(strategy);
   }
 }

--- a/src/configuration/resolvers/aws/parameter-store-configuration.resolver.ts
+++ b/src/configuration/resolvers/aws/parameter-store-configuration.resolver.ts
@@ -1,15 +1,16 @@
 import { GetParameterCommand, SSMClient } from '@aws-sdk/client-ssm';
-import { ConfigurationResolver } from '../configuration-resolver.interface';
-import { ResolvedValue } from '../resolved-value.interface';
+import { RemoteConfigurationResolverStrategy } from '../remote-configuration-resolver.strategy';
 
 /**
  * AWS Parameter Store configuration resolver.
  */
 export class AwsParameterStoreConfigurationResolver
-  implements ConfigurationResolver
+  implements RemoteConfigurationResolverStrategy
 {
-  private readonly AWS_PARAMETER_STORE_YAML_KEY = 'aws-parameter-store';
-  private readonly AWS_PARAMETER_STORE_ENV_PREFIX = 'AWS_PARAMETER_STORE';
+  configurationKeys: readonly string[] = [
+    'aws-parameter-store',
+    'AWS_PARAMETER_STORE',
+  ];
 
   /**
    * Creates a new instance of parameter store configuration resolver
@@ -19,97 +20,14 @@ export class AwsParameterStoreConfigurationResolver
   constructor(private readonly ssm: SSMClient) {}
 
   /**
-   * Fetches parameters and assign it to an object representation
-   * of the configuration.
+   * Resolves the aws parameter store value.
    *
-   * @param   {Record<string, any>} config the configuration object
-   * @returns {Record<string, any>}        the cofiguration with secret values assigned
-   * @throws  {Error}                      if unable to fetch the secret
+   * @param id the parameter id
+   * @returns the parameter value
    */
-  async resolve(config: Record<string, any>): Promise<Record<string, any>> {
-    const parameters = this.filterConfiguration(config);
-    const promises = this.buildBulkRequest(parameters);
-
-    const results = await Promise.all(promises);
-
-    const errors = results.filter((r) => !r.success);
-    if (errors && errors.length) {
-      throw new Error(
-        `Unable to resolve parameter:\n${errors
-          .map((e) => `${e.key}: ${e.id} - ${e.error?.message}`)
-          .join('\n')}`,
-      );
-    }
-
-    for (const result of results) {
-      config[result.key] = result.value;
-    }
-
-    return config;
-  }
-
-  /**
-   * Filters the configuration object by aws parameters store keys.
-   *
-   * @param   {Record<string, any>} config the configuration object
-   * @returns {Record<string, any>}        the filtered object
-   */
-  private filterConfiguration(
-    config: Record<string, any>,
-  ): Record<string, any> {
-    return Object.fromEntries(
-      Object.entries(config).filter(
-        ([key]) =>
-          key.startsWith(this.AWS_PARAMETER_STORE_YAML_KEY) ||
-          key.startsWith(this.AWS_PARAMETER_STORE_ENV_PREFIX),
-      ),
-    );
-  }
-
-  /**
-   * Resolves parameter values.
-   *
-   * @param {string} key the object key
-   * @param {string} id  the secret id
-   * @returns
-   */
-  private async resolveSecretValue(
-    key: string,
-    id: string,
-  ): Promise<ResolvedValue> {
-    try {
-      const payload = { Name: id, WithDecryption: true };
-      const command = new GetParameterCommand(payload);
-      const response = await this.ssm.send(command);
-      return {
-        id,
-        key,
-        value: response.Parameter?.Value,
-        success: true,
-      };
-    } catch (e) {
-      return {
-        id,
-        key,
-        error: e as Error,
-        success: false,
-      };
-    }
-  }
-
-  /**
-   * Creates a list of promises to get parameter values.
-   *
-   * @param   {Record<string, any>}      config the configuration object
-   * @returns {Promise<ResolvedValue>[]}        the get parameter value promises
-   */
-  private buildBulkRequest(
-    config: Record<string, any>,
-  ): Promise<ResolvedValue>[] {
-    const promises: Promise<ResolvedValue>[] = [];
-    for (const [key, value] of Object.entries(config)) {
-      promises.push(this.resolveSecretValue(key, value));
-    }
-    return promises;
+  async resolveSecretValue(id: string): Promise<string | undefined> {
+    const command = new GetParameterCommand({ Name: id, WithDecryption: true });
+    const response = await this.ssm.send(command);
+    return response.Parameter?.Value;
   }
 }

--- a/src/configuration/resolvers/aws/secrets-manager-configuration.resolver.ts
+++ b/src/configuration/resolvers/aws/secrets-manager-configuration.resolver.ts
@@ -2,17 +2,18 @@ import {
   GetSecretValueCommand,
   SecretsManagerClient,
 } from '@aws-sdk/client-secrets-manager';
-import { ConfigurationResolver } from '../configuration-resolver.interface';
-import { ResolvedValue } from '../resolved-value.interface';
+import { RemoteConfigurationResolverStrategy } from '../remote-configuration-resolver.strategy';
 
 /**
  * AWS Secrets Manager configuration resolver.
  */
 export class AwsSecretsManagerConfigurationResolver
-  implements ConfigurationResolver
+  implements RemoteConfigurationResolverStrategy
 {
-  private readonly AWS_SECRETS_AMANGER_YAML_KEY = 'aws-secrets-manager';
-  private readonly AWS_SECRETS_MANAGER_ENV_PREFIX = 'AWS_SECRETS_MANAGER';
+  configurationKeys: readonly string[] = [
+    'aws-secrets-manager',
+    'AWS_SECRETS_MANAGER',
+  ];
 
   /**
    * Creates a new instance of secrets manager configuration resolver
@@ -22,96 +23,14 @@ export class AwsSecretsManagerConfigurationResolver
   constructor(private readonly secretsManager: SecretsManagerClient) {}
 
   /**
-   * Fetches secrets and assign it to an object representation
-   * of the configuration.
+   * Resolves the secret value.
    *
-   * @param   {Record<string, any>} config the configuration object
-   * @returns {Record<string, any>}        the cofiguration with secret values assigned
-   * @throws  {Error}                      if unable to fetch the secret
-   */
-  async resolve(config: Record<string, any>): Promise<Record<string, any>> {
-    const secrets = this.filterConfiguration(config);
-    const promises = this.buildBulkRequest(secrets);
-
-    const results = await Promise.all(promises);
-
-    const errors = results.filter((r) => !r.success);
-    if (errors && errors.length) {
-      throw new Error(
-        `Unable to resolve secrets:\n${errors
-          .map((e) => `${e.key}: ${e.id} - ${e.error?.message}`)
-          .join('\n')}`,
-      );
-    }
-
-    for (const result of results) {
-      config[result.key] = result.value;
-    }
-
-    return config;
-  }
-
-  /**
-   * Filters the configuration object by aws secrets manager keys.
-   *
-   * @param   {Record<string, any>} config the configuration object
-   * @returns {Record<string, any>}        the filtered object
-   */
-  private filterConfiguration(
-    config: Record<string, any>,
-  ): Record<string, any> {
-    return Object.fromEntries(
-      Object.entries(config).filter(
-        ([key]) =>
-          key.startsWith(this.AWS_SECRETS_AMANGER_YAML_KEY) ||
-          key.startsWith(this.AWS_SECRETS_MANAGER_ENV_PREFIX),
-      ),
-    );
-  }
-
-  /**
-   * Resolves secret values.
-   *
-   * @param {string} key the object key
    * @param {string} id  the secret id
-   * @returns
+   * @returns the secret value
    */
-  private async resolveSecretValue(
-    key: string,
-    id: string,
-  ): Promise<ResolvedValue> {
-    try {
-      const command = new GetSecretValueCommand({ SecretId: id });
-      const response = await this.secretsManager.send(command);
-      return {
-        id,
-        key,
-        value: response.SecretString,
-        success: true,
-      };
-    } catch (e) {
-      return {
-        id,
-        key,
-        error: e as Error,
-        success: false,
-      };
-    }
-  }
-
-  /**
-   * Creates a list of promises to get secret values.
-   *
-   * @param   {Record<string, any>}      config the configuration object
-   * @returns {Promise<ResolvedValue>[]}        the get secret value promises
-   */
-  private buildBulkRequest(
-    config: Record<string, any>,
-  ): Promise<ResolvedValue>[] {
-    const promises: Promise<ResolvedValue>[] = [];
-    for (const [key, value] of Object.entries(config)) {
-      promises.push(this.resolveSecretValue(key, value));
-    }
-    return promises;
+  async resolveSecretValue(id: string): Promise<string | undefined> {
+    const command = new GetSecretValueCommand({ SecretId: id });
+    const response = await this.secretsManager.send(command);
+    return response.SecretString;
   }
 }

--- a/src/configuration/resolvers/azure/azure-key-vault-configuration-resolver.factory.ts
+++ b/src/configuration/resolvers/azure/azure-key-vault-configuration-resolver.factory.ts
@@ -1,5 +1,7 @@
 import { DefaultAzureCredential } from '@azure/identity';
 import { SecretClient } from '@azure/keyvault-secrets';
+import { ConfigurationResolver } from '../configuration-resolver.interface';
+import { RemoteConfigurationResolver } from '../remote-configuration.resolver';
 import { AzureKeyVaultConfigurationResolver } from './azure-key-vault-configuration.resolver';
 
 /**
@@ -8,7 +10,7 @@ import { AzureKeyVaultConfigurationResolver } from './azure-key-vault-configurat
 export class AzureKeyVaultConfigurationResolverFactory {
   /**
    * Creates a default azure keyvault secrets resolver
-   * using the provided keyvault url or the AZURE_KEYVAULT_URL
+   * using the provided keyvault url or the AZURE_KEY_VAULT_URL
    * environment variable.
    *
    * @param keyVaultUrl
@@ -16,15 +18,17 @@ export class AzureKeyVaultConfigurationResolverFactory {
    */
   static defaultKeyVaultConfigurationResolver(
     keyVaultUrl?: string,
-  ): AzureKeyVaultConfigurationResolver {
+  ): ConfigurationResolver {
     const url = keyVaultUrl || process.env.AZURE_KEY_VAULT_URL;
 
     if (!url) {
       throw new Error('Azure KeyVault URL is required');
     }
 
-    return new AzureKeyVaultConfigurationResolver(
+    const strategy = new AzureKeyVaultConfigurationResolver(
       new SecretClient(url, new DefaultAzureCredential()),
     );
+
+    return new RemoteConfigurationResolver(strategy);
   }
 }

--- a/src/configuration/resolvers/azure/azure-key-vault-configuration.resolver.ts
+++ b/src/configuration/resolvers/azure/azure-key-vault-configuration.resolver.ts
@@ -1,15 +1,13 @@
 import { SecretClient } from '@azure/keyvault-secrets';
-import { ConfigurationResolver } from '../configuration-resolver.interface';
-import { ResolvedValue } from '../resolved-value.interface';
+import { RemoteConfigurationResolverStrategy } from '../remote-configuration-resolver.strategy';
 
 /**
  * Azure Key Vault Secrets Configuration Resolver.
  */
 export class AzureKeyVaultConfigurationResolver
-  implements ConfigurationResolver
+  implements RemoteConfigurationResolverStrategy
 {
-  private readonly AZURE_KEY_VAULT_YAML_KEY = 'azure-key-vault';
-  private readonly AZURE_KEY_VAULT_ENV_PREFIX = 'AZURE_KEY_VAULT';
+  configurationKeys: readonly string[] = ['azure-key-vault', 'AZURE_KEY_VAULT'];
 
   /**
    * Creates a new instance of the Azure key vault secrets resolver
@@ -19,95 +17,13 @@ export class AzureKeyVaultConfigurationResolver
   constructor(private readonly client: SecretClient) {}
 
   /**
-   * Fetches the secrets and assign it to an object representation
-   * of the configuration.
+   * Resolves the secret value.
    *
-   * @param   {Record<string, any>} config the configuration object
-   * @returns {Record<string, any>}        the configuration with secret values assigned
-   * @throws  {Error}                      if unable to fetch the secret
-   */
-  async resolve(config: Record<string, any>): Promise<Record<string, any>> {
-    const parameters = this.filterConfiguration(config);
-    const promises = this.buildBulkRequest(parameters);
-
-    const results = await Promise.all(promises);
-
-    const errors = results.filter((r) => !r.success);
-    if (errors && errors.length) {
-      throw new Error(
-        `Unable to resolve parameter:\n${errors
-          .map((e) => `${e.key}: ${e.id} - ${e.error?.message}`)
-          .join('\n')}`,
-      );
-    }
-
-    for (const result of results) {
-      config[result.key] = result.value;
-    }
-
-    return config;
-  }
-
-  /**
-   * Filters the configuration object by azure key vault keys.
-   *
-   * @param   {Record<string, any>} config the configuration object
-   * @returns {Record<string, any>}        the filtered object
-   */
-  private filterConfiguration(
-    config: Record<string, any>,
-  ): Record<string, any> {
-    return Object.fromEntries(
-      Object.entries(config).filter(
-        ([key]) =>
-          key.startsWith(this.AZURE_KEY_VAULT_YAML_KEY) ||
-          key.startsWith(this.AZURE_KEY_VAULT_ENV_PREFIX),
-      ),
-    );
-  }
-
-  /**
-   * Resolves parameter values.
-   *
-   * @param {string} key the object key
    * @param {string} id  the secret id
-   * @returns
+   * @returns the secret value
    */
-  private async resolveSecretValue(
-    key: string,
-    id: string,
-  ): Promise<ResolvedValue> {
-    try {
-      const secret = await this.client.getSecret(id);
-      return {
-        id,
-        key,
-        value: secret.value,
-        success: true,
-      };
-    } catch (e) {
-      return {
-        id,
-        key,
-        error: e as Error,
-        success: false,
-      };
-    }
-  }
-
-  /**
-   * Creates a list of promises to get parameter values.
-   *
-   * @param   {Record<string, any>}      config the configuration object
-   * @returns {Promise<ResolvedValue>[]}        the get parameter value promises
-   */
-  private buildBulkRequest(
-    config: Record<string, any>,
-  ): Promise<ResolvedValue>[] {
-    const promises: Promise<ResolvedValue>[] = [];
-    for (const [key, value] of Object.entries(config)) {
-      promises.push(this.resolveSecretValue(key, value));
-    }
-    return promises;
+  async resolveSecretValue(id: string): Promise<string | undefined> {
+    const secret = await this.client.getSecret(id);
+    return secret.value;
   }
 }

--- a/src/configuration/resolvers/bitwarden/bitwarden-secrets-manager.resolver.ts
+++ b/src/configuration/resolvers/bitwarden/bitwarden-secrets-manager.resolver.ts
@@ -1,18 +1,16 @@
 import { BitwardenClient } from '@bitwarden/sdk-napi';
-import { ConfigurationResolver } from '../configuration-resolver.interface';
-import { ResolvedValue } from '../resolved-value.interface';
+import { RemoteConfigurationResolverStrategy } from '../remote-configuration-resolver.strategy';
 
 /**
  * Bitwarden Secrets Manager configuration resolver.
  */
 export class BitwardenSecretsManagerConfigurationResolver
-  implements ConfigurationResolver
+  implements RemoteConfigurationResolverStrategy
 {
-  private readonly BITWARDEN_SECRETS_MANAGER_YAML_KEY =
-    'bitwarden-secrets-manager';
-
-  private readonly BITWARDEN_SECRETS_MANAGER_ENV_PREFIX =
-    'BITWARDEN_SECRETS_MANAGER';
+  configurationKeys: readonly string[] = [
+    'bitwarden-secrets-manager',
+    'BITWARDEN_SECRETS_MANAGER',
+  ];
 
   /**
    * Creates a new instance of the configuration resolver
@@ -25,96 +23,15 @@ export class BitwardenSecretsManagerConfigurationResolver
   ) {}
 
   /**
-   * Fetches secrets and assign it to an object representation
-   * of the configuration.
-   *
-   * @param   {Record<string, any>} config the configuration object
-   * @returns {Record<string, any>}        the configuration with secret values assigned
-   * @throws  {Error}                      if unable to fetch the secret
-   */
-  async resolve(config: Record<string, any>): Promise<Record<string, any>> {
-    const parameters = this.filterConfiguration(config);
-    const promises = this.buildBulkRequest(parameters);
-
-    const results = await Promise.all(promises);
-
-    const errors = results.filter((r) => !r.success);
-    if (errors && errors.length) {
-      throw new Error(
-        `Unable to resolve parameter:\n${errors
-          .map((e) => `${e.key}: ${e.id} - ${e.error?.message}`)
-          .join('\n')}`,
-      );
-    }
-
-    for (const result of results) {
-      config[result.key] = result.value;
-    }
-
-    return config;
-  }
-
-  /**
-   * Filters the configuration object by aws parameters store keys.
-   *
-   * @param   {Record<string, any>} config the configuration object
-   * @returns {Record<string, any>}        the filtered object
-   */
-  private filterConfiguration(
-    config: Record<string, any>,
-  ): Record<string, any> {
-    return Object.fromEntries(
-      Object.entries(config).filter(
-        ([key]) =>
-          key.startsWith(this.BITWARDEN_SECRETS_MANAGER_YAML_KEY) ||
-          key.startsWith(this.BITWARDEN_SECRETS_MANAGER_ENV_PREFIX),
-      ),
-    );
-  }
-
-  /**
    * Resolves parameter values.
    *
    * @param {string} key the object key
    * @param {string} id  the secret id
    * @returns
    */
-  private async resolveSecretValue(
-    key: string,
-    id: string,
-  ): Promise<ResolvedValue> {
-    try {
-      await this.client.auth().loginAccessToken(this.accessToken);
-      const response = await this.client.secrets().get(id);
-      return {
-        id,
-        key,
-        value: response.value,
-        success: true,
-      };
-    } catch (e) {
-      return {
-        id,
-        key,
-        error: e as Error,
-        success: false,
-      };
-    }
-  }
-
-  /**
-   * Creates a list of promises to get parameter values.
-   *
-   * @param   {Record<string, any>}      config the configuration object
-   * @returns {Promise<ResolvedValue>[]}        the get parameter value promises
-   */
-  private buildBulkRequest(
-    config: Record<string, any>,
-  ): Promise<ResolvedValue>[] {
-    const promises: Promise<ResolvedValue>[] = [];
-    for (const [key, value] of Object.entries(config)) {
-      promises.push(this.resolveSecretValue(key, value));
-    }
-    return promises;
+  async resolveSecretValue(id: string): Promise<string | undefined> {
+    await this.client.auth().loginAccessToken(this.accessToken);
+    const response = await this.client.secrets().get(id);
+    return response.value;
   }
 }

--- a/src/configuration/resolvers/bitwarden/bitwarden-secrets-resolver.factory.ts
+++ b/src/configuration/resolvers/bitwarden/bitwarden-secrets-resolver.factory.ts
@@ -3,6 +3,8 @@ import {
   ClientSettings,
   DeviceType,
 } from '@bitwarden/sdk-napi';
+import { ConfigurationResolver } from '../configuration-resolver.interface';
+import { RemoteConfigurationResolver } from '../remote-configuration.resolver';
 import { BitwardenSecretsManagerConfigurationResolver } from './bitwarden-secrets-manager.resolver';
 import { BitwardenServerRegion } from './bitwarden-server.region';
 
@@ -42,7 +44,7 @@ export class BitwardenSecretsResolverFactory {
   static defaultBitwardenSecretsResolver(
     region: BitwardenServerRegion,
     accessToken?: string,
-  ): BitwardenSecretsManagerConfigurationResolver {
+  ): ConfigurationResolver {
     const token = accessToken || process.env.BWS_ACCESS_TOKEN;
 
     if (!token) {
@@ -55,7 +57,11 @@ export class BitwardenSecretsResolverFactory {
         : this.BITWARDEN_US_SETTINGS;
 
     const client = new BitwardenClient(settings);
+    const strategy = new BitwardenSecretsManagerConfigurationResolver(
+      client,
+      token,
+    );
 
-    return new BitwardenSecretsManagerConfigurationResolver(client, token);
+    return new RemoteConfigurationResolver(strategy);
   }
 }

--- a/src/configuration/resolvers/configuration-resolver.interface.ts
+++ b/src/configuration/resolvers/configuration-resolver.interface.ts
@@ -5,7 +5,7 @@ export interface ConfigurationResolver {
   /**
    * Resolves a remote configuration
    *
-   * @param {Record<string, any>} configuration the configuration obejct
+   * @param {Record<string, any>} configuration the configuration object
    */
   resolve(configuration: Record<string, any>): Promise<Record<string, any>>;
 }

--- a/src/configuration/resolvers/gcp/google-cloud-secret-manager.resolver.ts
+++ b/src/configuration/resolvers/gcp/google-cloud-secret-manager.resolver.ts
@@ -1,15 +1,16 @@
 import { SecretManagerServiceClient } from '@google-cloud/secret-manager';
-import { ConfigurationResolver } from '../configuration-resolver.interface';
-import { ResolvedValue } from '../resolved-value.interface';
+import { RemoteConfigurationResolverStrategy } from '../remote-configuration-resolver.strategy';
 
 /**
  * Google Cloud Secret Manager Configuration Resolver.
  */
 export class GoogleCloudSecretManagerConfigurationResolver
-  implements ConfigurationResolver
+  implements RemoteConfigurationResolverStrategy
 {
-  private readonly GCP_SECRET_MANAGER_YAML_KEY = 'gcp-secret-manager';
-  private readonly GCP_SECRET_MANAGER_ENV_PREFIX = 'GCP_SECRET_MANAGER';
+  configurationKeys: readonly string[] = [
+    'gcp-secret-manager',
+    'GCP_SECRET_MANAGER',
+  ];
 
   /**
    * Creates a new instance of the gcp secret manager resolver
@@ -19,96 +20,13 @@ export class GoogleCloudSecretManagerConfigurationResolver
   constructor(private readonly client: SecretManagerServiceClient) {}
 
   /**
-   * Fetches the secrets and assign it to an object representation
-   * of the configuration.
+   * Resolves the secret value.
    *
-   * @param   {Record<string, any>} config the configuration object
-   * @returns {Record<string, any>}        the configuration with secret values assigned
-   * @throws  {Error}                      if unable to fetch the secret
+   * @param {string} id the secret id
+   * @returns the secret value
    */
-  async resolve(config: Record<string, any>): Promise<Record<string, any>> {
-    const parameters = this.filterConfiguration(config);
-    const promises = this.buildBulkRequest(parameters);
-
-    const results = await Promise.all(promises);
-
-    const errors = results.filter((r) => !r.success);
-    if (errors && errors.length) {
-      throw new Error(
-        `Unable to resolve parameter:\n${errors
-          .map((e) => `${e.key}: ${e.id} - ${e.error?.message}`)
-          .join('\n')}`,
-      );
-    }
-
-    for (const result of results) {
-      config[result.key] = result.value;
-    }
-
-    return config;
-  }
-
-  /**
-   * Filters the configuration object by aws parameters store keys.
-   *
-   * @param   {Record<string, any>} config the configuration object
-   * @returns {Record<string, any>}        the filtered object
-   */
-  private filterConfiguration(
-    config: Record<string, any>,
-  ): Record<string, any> {
-    return Object.fromEntries(
-      Object.entries(config).filter(
-        ([key]) =>
-          key.startsWith(this.GCP_SECRET_MANAGER_YAML_KEY) ||
-          key.startsWith(this.GCP_SECRET_MANAGER_ENV_PREFIX),
-      ),
-    );
-  }
-
-  /**
-   * Resolves parameter values.
-   *
-   * @param {string} key the object key
-   * @param {string} id  the secret id
-   * @returns
-   */
-  private async resolveSecretValue(
-    key: string,
-    id: string,
-  ): Promise<ResolvedValue> {
-    try {
-      const payload = { name: id };
-      const [secret] = await this.client.accessSecretVersion(payload);
-      return {
-        id,
-        key,
-        value: secret.payload?.data?.toString(),
-        success: true,
-      };
-    } catch (e) {
-      return {
-        id,
-        key,
-        error: e as Error,
-        success: false,
-      };
-    }
-  }
-
-  /**
-   * Creates a list of promises to get parameter values.
-   *
-   * @param   {Record<string, any>}      config the configuration object
-   * @returns {Promise<ResolvedValue>[]}        the get parameter value promises
-   */
-  private buildBulkRequest(
-    config: Record<string, any>,
-  ): Promise<ResolvedValue>[] {
-    const promises: Promise<ResolvedValue>[] = [];
-    for (const [key, value] of Object.entries(config)) {
-      promises.push(this.resolveSecretValue(key, value));
-    }
-    return promises;
+  async resolveSecretValue(id: string): Promise<string | undefined> {
+    const [secret] = await this.client.accessSecretVersion({ name: id });
+    return secret.payload?.data?.toString();
   }
 }

--- a/src/configuration/resolvers/gcp/google-cloud-secrets-resolver.factory.ts
+++ b/src/configuration/resolvers/gcp/google-cloud-secrets-resolver.factory.ts
@@ -1,4 +1,6 @@
 import { SecretManagerServiceClient } from '@google-cloud/secret-manager';
+import { ConfigurationResolver } from '../configuration-resolver.interface';
+import { RemoteConfigurationResolver } from '../remote-configuration.resolver';
 import { GoogleCloudSecretManagerConfigurationResolver } from './google-cloud-secret-manager.resolver';
 
 /**
@@ -9,9 +11,10 @@ export class GoogleCloudSecretsResolverFactory {
    * The default secret manager configuration resolver
    * @returns {GoogleCloudSecretManagerConfigurationResolver} the default secret manager configuration resolver
    */
-  static defaultSecretManagerConfigurationResolver(): GoogleCloudSecretManagerConfigurationResolver {
-    return new GoogleCloudSecretManagerConfigurationResolver(
+  static defaultSecretManagerConfigurationResolver(): ConfigurationResolver {
+    const strategy = new GoogleCloudSecretManagerConfigurationResolver(
       new SecretManagerServiceClient(),
     );
+    return new RemoteConfigurationResolver(strategy);
   }
 }

--- a/src/configuration/resolvers/index.ts
+++ b/src/configuration/resolvers/index.ts
@@ -1,2 +1,4 @@
 export * from './configuration-resolver.interface';
+export * from './remote-configuration-resolver.strategy';
+export * from './remote-configuration.resolver';
 export * from './resolved-value.interface';

--- a/src/configuration/resolvers/remote-configuration-resolver.strategy.ts
+++ b/src/configuration/resolvers/remote-configuration-resolver.strategy.ts
@@ -1,0 +1,17 @@
+/**
+ * Remote configuration resolver strategy.
+ * This interface defines the contract for a remote configuration resolver strategy.
+ */
+export interface RemoteConfigurationResolverStrategy {
+  /**
+   * The configuration keys that this resolver can resolve.
+   */
+  configurationKeys: Readonly<string[]>;
+
+  /**
+   *  Resolves the secret value.
+   * @param id the secret id
+   * @returns the secret value
+   */
+  resolveSecretValue(id: string): Promise<string | undefined>;
+}

--- a/src/configuration/resolvers/remote-configuration.resolver.ts
+++ b/src/configuration/resolvers/remote-configuration.resolver.ts
@@ -1,0 +1,104 @@
+import { ConfigurationResolver } from './configuration-resolver.interface';
+import { RemoteConfigurationResolverStrategy } from './remote-configuration-resolver.strategy';
+import { ResolvedValue } from './resolved-value.interface';
+
+/**
+ * The remote configuration resolver.
+ * This class resolves configuration values from a remote source.
+ */
+export class RemoteConfigurationResolver implements ConfigurationResolver {
+  /**
+   * Creates a new instance of RemoteConfigurationResolver.
+   *
+   * @param strategy the remote configuration resolver strategy
+   */
+  constructor(private readonly strategy: RemoteConfigurationResolverStrategy) {}
+
+  /**
+   * Resolves the configuration values.
+   *
+   * @param configuration the configuration object
+   * @returns the resolved configuration object
+   */
+  async resolve(config: Record<string, any>): Promise<Record<string, any>> {
+    const parameters = this.filterConfiguration(config);
+    const promises = this.buildBulkRequest(parameters);
+
+    const results = await Promise.all(promises);
+
+    const errors = results.filter((r) => !r.success);
+    if (errors && errors.length) {
+      throw new Error(
+        `Unable to resolve parameter:\n${errors
+          .map((e) => `${e.key}: ${e.id} - ${e.error?.message}`)
+          .join('\n')}`,
+      );
+    }
+
+    for (const result of results) {
+      config[result.key] = result.value;
+    }
+
+    return config;
+  }
+
+  /**
+   * Resolves the secret value.
+   *
+   * @param {string} key the object key
+   * @param {string} id  the secret id
+   * @returns the resolved value
+   */
+  private async resolveSecretValue(
+    key: string,
+    id: string,
+  ): Promise<ResolvedValue> {
+    try {
+      const secret = await this.strategy.resolveSecretValue(id);
+      return {
+        id,
+        key,
+        value: secret,
+        success: true,
+      };
+    } catch (e) {
+      return {
+        id,
+        key,
+        error: e as Error,
+        success: false,
+      };
+    }
+  }
+
+  /**
+   * Filters the configuration keys that can be resolved by the provided strategy.
+   *
+   * @param   {Record<string, any>} config the configuration object
+   * @returns {Record<string, any>}        the filtered object
+   */
+  private filterConfiguration(
+    config: Record<string, any>,
+  ): Record<string, any> {
+    const entries = Object.entries(config).filter(([key]) =>
+      this.strategy.configurationKeys.some((k) => key.startsWith(k)),
+    );
+    return Object.fromEntries(entries);
+  }
+
+  /**
+   * Creates a list of promises to resolve the configuration values.
+   *
+   * @param   {Record<string, any>}      config the configuration object
+   * @returns {Promise<ResolvedValue>[]}        the get parameter value promises
+   */
+  private buildBulkRequest(
+    config: Record<string, any>,
+  ): Promise<ResolvedValue>[] {
+    const promises: Promise<ResolvedValue>[] = [];
+    for (const [key, value] of Object.entries(config)) {
+      promises.push(this.resolveSecretValue(key, value));
+    }
+    return promises;
+  }
+}

--- a/test/resolvers/azure-key-vault-configuration.resolver.spec.ts
+++ b/test/resolvers/azure-key-vault-configuration.resolver.spec.ts
@@ -2,6 +2,7 @@
 import { getSecretMock, secretClientMock } from '../mock/azure.mock';
 
 import { SecretClient } from '@azure/keyvault-secrets';
+import { RemoteConfigurationResolver } from '../../src';
 import {
   AzureKeyVaultConfigurationResolver,
   AzureKeyVaultConfigurationResolverFactory,
@@ -25,7 +26,9 @@ describe('AzureKeyVaultConfigurationResolver', () => {
 
       getSecretMock.mockRejectedValue(new Error('Unable to fetch the secret'));
 
-      const resolver = new AzureKeyVaultConfigurationResolver(secretClientMock);
+      const resolver = new RemoteConfigurationResolver(
+        new AzureKeyVaultConfigurationResolver(secretClientMock),
+      );
 
       await expect(resolver.resolve(config)).rejects.toThrow(Error);
 
@@ -41,7 +44,9 @@ describe('AzureKeyVaultConfigurationResolver', () => {
 
       getSecretMock.mockResolvedValue({ value: 'mySecretDBPassword' });
 
-      const resolver = new AzureKeyVaultConfigurationResolver(secretClientMock);
+      const resolver = new RemoteConfigurationResolver(
+        new AzureKeyVaultConfigurationResolver(secretClientMock),
+      );
 
       const result = await resolver.resolve(config);
 
@@ -59,7 +64,7 @@ describe('AzureKeyVaultConfigurationResolver', () => {
           'test-url',
         );
 
-      expect(resolver).toBeInstanceOf(AzureKeyVaultConfigurationResolver);
+      expect(resolver).toBeInstanceOf(RemoteConfigurationResolver);
       expect(SecretClient).toHaveBeenCalledTimes(1);
     });
   });

--- a/test/resolvers/bitwarden-secrets-manager.resolver.spec.ts
+++ b/test/resolvers/bitwarden-secrets-manager.resolver.spec.ts
@@ -6,6 +6,7 @@ import {
 } from '../mock/bitwarden.mock';
 
 import { BitwardenClient } from '@bitwarden/sdk-napi';
+import { RemoteConfigurationResolver } from '../../src';
 import {
   BitwardenSecretsManagerConfigurationResolver,
   BitwardenSecretsResolverFactory,
@@ -31,9 +32,11 @@ describe('BitwardenSecretsManagerConfigurationResolver', () => {
         new Error('Unable to Authenticate'),
       );
 
-      const resolver = new BitwardenSecretsManagerConfigurationResolver(
-        bitwardenClientMock,
-        testAccessToken,
+      const resolver = new RemoteConfigurationResolver(
+        new BitwardenSecretsManagerConfigurationResolver(
+          bitwardenClientMock,
+          testAccessToken,
+        ),
       );
 
       await expect(
@@ -55,9 +58,11 @@ describe('BitwardenSecretsManagerConfigurationResolver', () => {
         new Error('Secret ID not found'),
       );
 
-      const resolver = new BitwardenSecretsManagerConfigurationResolver(
-        bitwardenClientMock,
-        testAccessToken,
+      const resolver = new RemoteConfigurationResolver(
+        new BitwardenSecretsManagerConfigurationResolver(
+          bitwardenClientMock,
+          testAccessToken,
+        ),
       );
 
       await expect(
@@ -80,9 +85,11 @@ describe('BitwardenSecretsManagerConfigurationResolver', () => {
         value: 'test-secret',
       });
 
-      const resolver = new BitwardenSecretsManagerConfigurationResolver(
-        bitwardenClientMock,
-        testAccessToken,
+      const resolver = new RemoteConfigurationResolver(
+        new BitwardenSecretsManagerConfigurationResolver(
+          bitwardenClientMock,
+          testAccessToken,
+        ),
       );
 
       const result = await resolver.resolve({
@@ -108,9 +115,7 @@ describe('BitwardenSecretsManagerConfigurationResolver', () => {
           'test-access-token',
         );
 
-      expect(resolver).toBeInstanceOf(
-        BitwardenSecretsManagerConfigurationResolver,
-      );
+      expect(resolver).toBeInstanceOf(RemoteConfigurationResolver);
 
       expect(BitwardenClient).toHaveBeenCalledWith({
         apiUrl: 'https://api.bitwarden.eu',
@@ -127,9 +132,7 @@ describe('BitwardenSecretsManagerConfigurationResolver', () => {
           'test-access-token',
         );
 
-      expect(resolver).toBeInstanceOf(
-        BitwardenSecretsManagerConfigurationResolver,
-      );
+      expect(resolver).toBeInstanceOf(RemoteConfigurationResolver);
 
       expect(BitwardenClient).toHaveBeenCalledWith({
         apiUrl: 'https://api.bitwarden.com',

--- a/test/resolvers/gcp-secret-manager.resolver.spec.ts
+++ b/test/resolvers/gcp-secret-manager.resolver.spec.ts
@@ -5,14 +5,13 @@ import {
 } from '../mock/gcp.mock';
 
 import { SecretManagerServiceClient } from '@google-cloud/secret-manager';
+import { RemoteConfigurationResolver } from '../../src';
 import {
   GoogleCloudSecretManagerConfigurationResolver,
   GoogleCloudSecretsResolverFactory,
 } from '../../src/configuration/resolvers/gcp';
 
 describe('GoogleCloudSecretManagerConfigurationResolver', () => {
-  const testAccessToken = '';
-
   beforeEach(() => {
     accessSecretVersionMock.mockReset();
     jest.clearAllMocks();
@@ -33,8 +32,10 @@ describe('GoogleCloudSecretManagerConfigurationResolver', () => {
         new Error('Unable to fetch the secret'),
       );
 
-      const resolver = new GoogleCloudSecretManagerConfigurationResolver(
-        secretManagerServiceClientMock,
+      const resolver = new RemoteConfigurationResolver(
+        new GoogleCloudSecretManagerConfigurationResolver(
+          secretManagerServiceClientMock,
+        ),
       );
 
       await expect(resolver.resolve(config)).rejects.toThrow(Error);
@@ -55,8 +56,10 @@ describe('GoogleCloudSecretManagerConfigurationResolver', () => {
         { payload: { data: Buffer.from('test-secret') } },
       ]);
 
-      const resolver = new GoogleCloudSecretManagerConfigurationResolver(
-        secretManagerServiceClientMock,
+      const resolver = new RemoteConfigurationResolver(
+        new GoogleCloudSecretManagerConfigurationResolver(
+          secretManagerServiceClientMock,
+        ),
       );
 
       const result = await resolver.resolve(config);
@@ -75,10 +78,7 @@ describe('GoogleCloudSecretManagerConfigurationResolver', () => {
       const resolver =
         GoogleCloudSecretsResolverFactory.defaultSecretManagerConfigurationResolver();
 
-      expect(resolver).toBeInstanceOf(
-        GoogleCloudSecretManagerConfigurationResolver,
-      );
-
+      expect(resolver).toBeInstanceOf(RemoteConfigurationResolver);
       expect(SecretManagerServiceClient).toHaveBeenCalledTimes(1);
     });
   });

--- a/test/resolvers/parameter-store-configuration.resolver.spec.ts
+++ b/test/resolvers/parameter-store-configuration.resolver.spec.ts
@@ -2,6 +2,7 @@
 import { systemsManagerSendMock } from '../mock/aws.mock';
 
 import { SSMClient } from '@aws-sdk/client-ssm';
+import { RemoteConfigurationResolver } from '../../src';
 import { AwsParameterStoreConfigurationResolver } from '../../src/configuration/resolvers/aws';
 
 describe('AwsParameterStoreConfigurationResolver', () => {
@@ -19,8 +20,8 @@ describe('AwsParameterStoreConfigurationResolver', () => {
         new Error('Parameter not found'),
       );
 
-      const resolver = new AwsParameterStoreConfigurationResolver(
-        new SSMClient(),
+      const resolver = new RemoteConfigurationResolver(
+        new AwsParameterStoreConfigurationResolver(new SSMClient()),
       );
 
       await expect(
@@ -36,8 +37,8 @@ describe('AwsParameterStoreConfigurationResolver', () => {
         Parameter: { Value: secret },
       });
 
-      const resolver = new AwsParameterStoreConfigurationResolver(
-        new SSMClient(),
+      const resolver = new RemoteConfigurationResolver(
+        new AwsParameterStoreConfigurationResolver(new SSMClient()),
       );
 
       const config = await resolver.resolve({

--- a/test/resolvers/secrets-manager-configuration.resolver.spec.ts
+++ b/test/resolvers/secrets-manager-configuration.resolver.spec.ts
@@ -2,6 +2,7 @@
 import { secretsManagerSendMock } from '../mock/aws.mock';
 
 import { SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
+import { RemoteConfigurationResolver } from '../../src';
 import { AwsSecretsManagerConfigurationResolver } from '../../src/configuration/resolvers/aws';
 
 describe('AwsSecretsManagerConfigurationResolver', () => {
@@ -17,8 +18,8 @@ describe('AwsSecretsManagerConfigurationResolver', () => {
     it('should throw error when unable to resolve secret', async () => {
       secretsManagerSendMock.mockRejectedValue(new Error('Secret not found'));
 
-      const resolver = new AwsSecretsManagerConfigurationResolver(
-        new SecretsManagerClient(),
+      const resolver = new RemoteConfigurationResolver(
+        new AwsSecretsManagerConfigurationResolver(new SecretsManagerClient()),
       );
 
       await expect(
@@ -32,8 +33,8 @@ describe('AwsSecretsManagerConfigurationResolver', () => {
       const secret = 'test';
       secretsManagerSendMock.mockResolvedValue({ SecretString: secret });
 
-      const resolver = new AwsSecretsManagerConfigurationResolver(
-        new SecretsManagerClient(),
+      const resolver = new RemoteConfigurationResolver(
+        new AwsSecretsManagerConfigurationResolver(new SecretsManagerClient()),
       );
 
       const config = await resolver.resolve({


### PR DESCRIPTION
This PR introduces a `RemoteConfigurationResolver` abstraction to remove duplicated code when resolving configuration secrets from different providers.