### PR TITLE
fix: set forbidUnknownValues to false when validating configuration objects

### DIFF
--- a/src/configify.module.ts
+++ b/src/configify.module.ts
@@ -1,5 +1,5 @@
 import { DynamicModule, Module, Provider } from '@nestjs/common';
-import { validateSync } from 'class-validator';
+import { validateSync, ValidatorOptions } from 'class-validator';
 import * as fs from 'fs';
 import { resolve } from 'path';
 import {
@@ -29,6 +29,15 @@ import { Variables } from './interpolation/variables';
  */
 @Module({})
 export class ConfigifyModule {
+  /**
+   * class-validator options used to validate the configuration objects.
+   * The `forbidUnknownValues` must be false in order to not fail the validation
+   * when the configuration class has no validation decorated attributes.
+   */
+  private static readonly VALIDATION_OPTIONS: ValidatorOptions = {
+    forbidUnknownValues: false,
+  };
+
   /**
    * The default configuration files.
    * If no configuration files are provided this module will
@@ -140,7 +149,7 @@ export class ConfigifyModule {
         instance[attribute] = value;
       }
 
-      const errors = validateSync(instance);
+      const errors = validateSync(instance, this.VALIDATION_OPTIONS);
       if (errors && errors.length) {
         throw new Error(
           `validation constraints violated:\n${errors


### PR DESCRIPTION
This class-validator [PR](https://github.com/typestack/class-validator/pull/2196) introduced a change to set the validation configuration `forbidUnknownValues` to `true` making the validation fail if the class has [no validation decorated attributes](https://github.com/cduff/class-validator/blob/4ac641ed3907f2ba2c483a66efec7ba09b311b81/src/validation/ValidationExecutor.ts#L70).

In order to not force any validation decorated attribute in the `@Configuration` decorated classes the `forbidUnknownValues` is set to `false` when validating configuration classes.

Fixes #119 