### PR TITLE
maint: implement automated release pipeline for npm publish

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,57 @@
+name: Pre Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-type:
+        description: 'Release type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - prepatch
+          - preminor
+          - premajor
+          - prerelease
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  pre-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+
+      - name: Bump version
+        run: npm version ${{ github.event.inputs.release-type }} --no-git-tag-version
+
+      - name: Get version
+        id: package
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'maint: bump version to v${{ steps.package.outputs.version }}'
+          title: 'chore: release v${{ steps.package.outputs.version }}'
+          body: |
+            ## Release v${{ steps.package.outputs.version }}
+
+            This PR bumps the version to `v${{ steps.package.outputs.version }}`.
+
+            **Release type:** `${{ github.event.inputs.release-type }}`
+
+            Merging this PR will automatically create a GitHub release and trigger the npm publish workflow.
+          branch: release/v${{ steps.package.outputs.version }}
+          labels: release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,16 +1,24 @@
 name: Publish to NPM
+
 on:
-  release:
-    types: [created]
+  workflow_run:
+    workflows:
+      - Release
+    types:
+      - completed
+
 permissions:
   id-token: write
   contents: read
+
 jobs:
-  build:
+  publish:
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -18,11 +26,19 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           always-auth: true
           scope: '@itgorillaz'
+
       - name: Update npm
         run: npm install -g npm@11.6.2
+
       - name: Install dependencies and build
         run: npm ci && npm run build
+
       - name: Copy files for distribution
         run: cp package.json README.md LICENSE dist
+
+      - name: Get version
+        id: package
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
       - name: Publish package on NPM
-        run: npm publish ./dist --access public
+        run: npm publish ./dist --access public ${{ contains(steps.package.outputs.version, '-') && '--tag next' || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+      - master
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Get version
+        id: package
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.package.outputs.version }}
+          name: v${{ steps.package.outputs.version }}
+          generate_release_notes: true
+          prerelease: ${{ contains(steps.package.outputs.version, '-') }}


### PR DESCRIPTION
Adds pre-release and release workflows to automate the version bump, GitHub release creation, and npm publish flow. 
The publish workflow is now triggered by the release workflow completion instead of a manual GitHub release event, and applies the `next` dist-tag for pre-release versions.